### PR TITLE
[FIX] Fix issue #1547 消費税率に0を指定できない

### DIFF
--- a/src/Eccube/Controller/Admin/Product/ProductController.php
+++ b/src/Eccube/Controller/Admin/Product/ProductController.php
@@ -311,8 +311,12 @@ class ProductController extends AbstractController
                     // 個別消費税
                     $BaseInfo = $app['eccube.repository.base_info']->get();
                     if ($BaseInfo->getOptionProductTaxRule() == Constant::ENABLED) {
-                        if ($ProductClass->getTaxRate()) {
-                            if ($ProductClass->getTaxRule() && !$ProductClass->getTaxRule()->getDelFlg()) {
+                        if ($ProductClass->getTaxRate() !== null) {
+                            if ($ProductClass->getTaxRule()) {
+                                if ($ProductClass->getTaxRule()->getDelFlg() == Constant::ENABLED) {
+                                    $ProductClass->getTaxRule()->setDelFlg(Constant::DISABLED);
+                                }
+
                                 $ProductClass->getTaxRule()->setTaxRate($ProductClass->getTaxRate());
                             } else {
                                 $taxrule = $app['eccube.repository.tax_rule']->newTaxRule();

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -49,7 +49,7 @@ class ProductControllerTest extends AbstractAdminWebTestCase
             'description_detail' => $faker->text,
             'description_list' => $faker->paragraph,
             'Category' => null,
-            'Tag' => '',
+            'Tag' => 1,
             'search_word' => $faker->word,
             'free_area' => $faker->text,
             'Status' => 1,

--- a/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/ProductContorllerTest.php
@@ -25,6 +25,7 @@
 namespace Eccube\Tests\Web\Admin\Product;
 
 use Eccube\Common\Constant;
+use Eccube\Entity\TaxRule;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 
 class ProductControllerTest extends AbstractAdminWebTestCase
@@ -198,17 +199,85 @@ class ProductControllerTest extends AbstractAdminWebTestCase
         return $TestProductStock;
     }
 
-    public function testEditWithPostTaxRate()
+    /**
+     * @param $taxRate
+     * @param $expected
+     * @dataProvider dataNewProductProvider
+     */
+    public function testNewWithPostTaxRate($taxRate, $expected)
+    {
+        // Give
+        $BaseInfo = $this->app['eccube.repository.base_info']->get();
+        $BaseInfo->setOptionProductTaxRule(Constant::ENABLED);
+        $formData = $this->createFormData();
+
+        $formData['class']['tax_rate'] = $taxRate;
+        // When
+        $this->client->request(
+            'POST',
+            $this->app->url('admin_product_product_new'),
+            array('admin_product' => $formData)
+        );
+
+        // Then
+        $this->assertTrue($this->client->getResponse()->isRedirection());
+
+        $arrTmp = explode('/', $this->client->getResponse()->getTargetUrl());
+        $productId = $arrTmp[count($arrTmp)-2];
+        $Product = $this->app['eccube.repository.product']->find($productId);
+
+        $this->expected = $expected;
+        $Taxrule = $this->app['eccube.repository.tax_rule']->findOneBy(array('Product' => $Product));
+        $taxRate = is_null($taxRate) ? null : $Taxrule->getTaxRate();
+        $this->actual = $taxRate;
+        $this->assertTrue($this->actual === $this->expected);
+    }
+
+    public function dataNewProductProvider()
+    {
+        return array(
+            array(null, null),
+            array("0", "0"),
+            array("1", "1"),
+        );
+    }
+
+    /**
+     * @param $taxRate
+     * @param $expected
+     * @dataProvider dataEditProductProvider
+     */
+    public function testEditWithPostTaxRate($taxRate, $hasTaxRule, $expected)
     {
         // Give
         $BaseInfo = $this->app['eccube.repository.base_info']->get();
         $BaseInfo->setOptionProductTaxRule(Constant::ENABLED);
         $Product = $this->createProduct();
         $formData = $this->createFormData();
-        $formData['class']['tax_rate'] = "0";
+        $formData['class']['tax_rate'] = $taxRate;
+        if ($hasTaxRule) {
+            $ProductClasses = $Product->getProductClasses();
+            $TaxRule = $this->app['eccube.repository.tax_rule']->find(\Eccube\Entity\TaxRule::DEFAULT_TAX_RULE_ID);
+            $CalcRule = $TaxRule->getCalcRule();
+            $fake = $this->getFaker();
+            foreach ($ProductClasses as $ProductClass) {
+                $Taxrule = new TaxRule();
+                $Taxrule->setProductClass($ProductClass)
+                    ->setCreator($Product->getCreator())
+                    ->setProduct($Product)
+                    ->setCalcRule($CalcRule)
+                    ->setTaxRate($fake->randomNumber(2))
+                    ->setTaxAdjust(0)
+                    ->setApplyDate(new \DateTime())
+                    ->setDelFlg(Constant::ENABLED);
+                $ProductClass->setTaxRule($Taxrule);
+                $this->app['orm.em']->persist($Taxrule);
+                $this->app['orm.em']->flush();
+            }
+        }
 
         // When
-        $crawler = $this->client->request(
+        $this->client->request(
             'POST',
             $this->app->url('admin_product_product_edit', array('id' => $Product->getId())),
             array('admin_product' => $formData)
@@ -216,13 +285,27 @@ class ProductControllerTest extends AbstractAdminWebTestCase
 
         // Then
         $this->assertTrue($this->client->getResponse()->isRedirect($this->app->url('admin_product_product_edit', array('id' => $Product->getId()))));
-        $this->expected = $formData['class']['tax_rate'];
-        $Taxrule = $this->app['eccube.repository.tax_rule']->findOneBy(array('Product' => $Product));
-        $this->actual = $Taxrule->getTaxRate();
-        $this->assertTrue($this->actual === $this->expected);
 
-        $this->actual = $Taxrule->getDelFlg();
-        $this->expected = Constant::DISABLED;
-        $this->verify();
+        $this->expected = $expected;
+        $Taxrule = $this->app['eccube.repository.tax_rule']->findOneBy(array('Product' => $Product));
+
+        if (is_null($taxRate)) {
+            $this->actual = null;
+        } else {
+            $this->actual = $Taxrule->getTaxRate();
+        }
+
+        $this->assertTrue($this->actual === $this->expected);
+    }
+
+    public function dataEditProductProvider()
+    {
+        return array(
+            array(null, true, null),
+            array("0", true, "0"),
+            array("10", true, "10"),
+            array("0", false, "0"),
+            array("10", false, "10"),
+        );
     }
 }


### PR DESCRIPTION
[FIX] Fix issue  [#1547](https://github.com/EC-CUBE/ec-cube/issues/1547) 消費税率に0を指定できない
