### PR TITLE
会員複数配送時、「お届け先の追加」から、新しいお届け先の登録ができない #1285:

### DIFF
--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -666,6 +666,12 @@ class ShoppingController extends AbstractController
             $app->addError('front.shopping.order.error');
             return $app->redirect($app->url('shopping_error'));
         }
+
+        $BaseInfo = $app['eccube.repository.base_info']->get();
+        if (!$id && $BaseInfo->getOptionMultipleShipping() == Constant::DISABLED) {
+            throw new NotFoundHttpException();
+        }
+
         $Shipping = $Order->getShippings()->first();
         if ($id) {
             $Shipping = $Order->findShipping($id);
@@ -680,7 +686,7 @@ class ShoppingController extends AbstractController
         $CustomerAddress = new CustomerAddress();
         if ($app->isGranted('IS_AUTHENTICATED_FULLY')) {
             $CustomerAddress->setCustomer($Customer);
-        } elseif ($id) {
+        } else {
             $CustomerAddress->setFromShipping($Shipping);
         }
 

--- a/src/Eccube/Controller/ShoppingController.php
+++ b/src/Eccube/Controller/ShoppingController.php
@@ -1145,6 +1145,7 @@ class ShoppingController extends AbstractController
                             'shipmentItems' => $shipmentItems,
                             'compItemQuantities' => $compItemQuantities,
                             'errors' => $errors,
+                            'Customer' => $Customer
                         ));
                     }
                 }

--- a/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
@@ -139,11 +139,13 @@ $(function() {
                             </div>
                         </div><!--/cart_item-->
                         <p id="list_box__add_button">
+                        {% if is_granted('ROLE_USER') %}
                             {% if Customer.CustomerAddresses|length < app.config.deliv_addr_max %}
                                 <a href="{{ url('shopping_shipping_edit', {'id': 0}) }}" class="btn btn-default btn-sm">新規お届け先を追加する</a>
                             {% else %}
                                 <span id="list_box__deliv_addr_max_message" class="text-danger">お届け先登録上限の{{ app.config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
                             {% endif %}
+                        {% endif %}
                         </p>
                         <div id="item{{ idx }}">
                             {% for shipping in form.shipping_multiple[idx].shipping %}

--- a/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
@@ -84,6 +84,14 @@ $(function() {
 
 {% block main %}
     <h1 class="page-heading">お届け先の複数指定</h1>
+    <p id="list_box__add_button">
+        {% if Customer.CustomerAddresses|length < app.config.deliv_addr_max %}
+            <a href="{{ url('shopping_shipping_edit', {'id': 0}) }}" class="btn btn-default btn-sm">新規お届け先を追加する</a>
+        {% else %}
+            <span id="list_box__deliv_addr_max_message" class="text-danger">お届け先登録上限の{{ app.config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
+        {% endif %}
+    </p>
+
     <div id="multiple_wrap" class="container-fluid">
         <form id="shipping-multiple-form" method="post" action="{{ url('shopping_shipping_multiple') }}">
             {{ form_widget(form._token) }}

--- a/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
+++ b/src/Eccube/Resource/template/default/Shopping/shipping_multiple.twig
@@ -84,13 +84,6 @@ $(function() {
 
 {% block main %}
     <h1 class="page-heading">お届け先の複数指定</h1>
-    <p id="list_box__add_button">
-        {% if Customer.CustomerAddresses|length < app.config.deliv_addr_max %}
-            <a href="{{ url('shopping_shipping_edit', {'id': 0}) }}" class="btn btn-default btn-sm">新規お届け先を追加する</a>
-        {% else %}
-            <span id="list_box__deliv_addr_max_message" class="text-danger">お届け先登録上限の{{ app.config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
-        {% endif %}
-    </p>
 
     <div id="multiple_wrap" class="container-fluid">
         <form id="shipping-multiple-form" method="post" action="{{ url('shopping_shipping_multiple') }}">
@@ -145,7 +138,13 @@ $(function() {
                                 <!--/item_box-->
                             </div>
                         </div><!--/cart_item-->
-
+                        <p id="list_box__add_button">
+                            {% if Customer.CustomerAddresses|length < app.config.deliv_addr_max %}
+                                <a href="{{ url('shopping_shipping_edit', {'id': 0}) }}" class="btn btn-default btn-sm">新規お届け先を追加する</a>
+                            {% else %}
+                                <span id="list_box__deliv_addr_max_message" class="text-danger">お届け先登録上限の{{ app.config.deliv_addr_max }}件に達しています。お届け先を入力したい場合は、削除か変更を行ってください</span>
+                            {% endif %}
+                        </p>
                         <div id="item{{ idx }}">
                             {% for shipping in form.shipping_multiple[idx].shipping %}
                                 <div id="item{{ idx }}-{{ loop.index0 }}" class="shipping_item item{{ idx }} form-inline" style="margin-bottom: 5px;">
@@ -163,6 +162,7 @@ $(function() {
                                 </div>
                             {% endfor %}
                         </div>
+
                         <p id="multiple_list__add_button">
                             <button id="button__add" type="button" class="btn btn-default btn-sm add" data-idx="{{ idx }}">お届け先追加</button>
                         </p>


### PR DESCRIPTION
会員で、複数配送指定時、新たにお届け先を登録するためには、お届け先の「変更」ボタンから登録した後、「お届け先の追加」から複数配送指定をしなくてはならない。

大変わかりづらいため、「お届け先の追加」からでも、新たにお届け先を登録できる動線が欲しい
https://travis-ci.org/lqdung-lockon/ec-cube/builds/142132951
