### PR TITLE
fixing issue #1405 :

### DIFF
--- a/src/Eccube/Repository/PageLayoutRepository.php
+++ b/src/Eccube/Repository/PageLayoutRepository.php
@@ -106,6 +106,18 @@ class PageLayoutRepository extends EntityRepository
         foreach ($anyResults as $anyResult) {
             $BlockPositions = $anyResult->getBlockPositions();
             foreach ($BlockPositions as $BlockPosition) {
+
+                $duplicated = $OwnBlockPosition->filter(
+                    function ($entry) use ($BlockPosition) {
+                        if (($entry->getTargetId() == $BlockPosition->getTargetId()) && ($entry->getBlockId() == $BlockPosition->getBlockId())) {
+                            return true;
+                        }
+                    }
+                );
+                if (count($duplicated) > 0) {
+                    continue;
+                }
+
                 if (!$OwnBlockPosition->contains($BlockPosition)) {
                     $ownResult->addBlockPosition($BlockPosition);
                 }
@@ -153,6 +165,18 @@ class PageLayoutRepository extends EntityRepository
         foreach ($anyResults as $anyResult) {
             $BlockPositions = $anyResult->getBlockPositions();
             foreach ($BlockPositions as $BlockPosition) {
+
+                $duplicated = $OwnBlockPosition->filter(
+                    function ($entry) use ($BlockPosition) {
+                        if (($entry->getTargetId() == $BlockPosition->getTargetId()) && ($entry->getBlockId() == $BlockPosition->getBlockId())) {
+                            return true;
+                        }
+                    }
+                );
+                if (count($duplicated) > 0) {
+                    continue;
+                }
+
                 if (!$OwnBlockPosition->contains($BlockPosition)) {
                     $ownResult->addBlockPosition($BlockPosition);
                 }

--- a/tests/Eccube/Tests/Repository/PageLayoutRepositoryTest.php
+++ b/tests/Eccube/Tests/Repository/PageLayoutRepositoryTest.php
@@ -104,6 +104,58 @@ class PageLayoutRepositoryTest extends EccubeTestCase
         }
     }
 
+
+    /**
+     * fixed bug #1405
+     */
+    protected function addBlock2target($id, $pageId, $blockId, $rowId, $targetId, $TargetPageLayout, $anywhere)
+    {
+        $TargetPageLayout = $this->app['eccube.repository.page_layout']->get($this->DeviceType, $pageId);
+
+        $BlockPosition = new \Eccube\Entity\BlockPosition();
+        $Block = $this->app['orm.em']->getRepository('Eccube\Entity\Block')
+            ->findOneBy(array(
+                'id' => $id,
+                'DeviceType' => $this->DeviceType,
+            ));
+        $BlockPosition
+            ->setPageId($pageId)
+            ->setBlockId($blockId)
+            ->setBlockRow($rowId)
+            ->setTargetId($targetId)
+            ->setBlock($Block)
+            ->setPageLayout($TargetPageLayout)
+            ->setAnywhere($anywhere);
+        if ($id == 0) {
+            $BlockPosition->setAnywhere(0);
+        }
+        $TargetPageLayout->addBlockPosition($BlockPosition);
+        $this->app['orm.em']->persist($BlockPosition);
+    }
+
+    public function testGetByUrlDuplication()
+    {
+        // add block A into ITEM page in target 6
+        $this->addBlock2target(10, 2, 10, 1, 6, 2, 0);
+        // add block A into TOP page  in target 6 with check  "All pages"
+        $this->addBlock2target(10, 1, 10, 2, 6, 2, 1);
+
+        $PageLayout = $this->app['eccube.repository.page_layout']
+            ->getByUrl($this->DeviceType, 'product_list');
+
+        //check block A not show twice
+        $showNo = 0;
+        foreach ($PageLayout->getBlockPositions() as $BlockPosition) {
+            if ((6 == $BlockPosition->getTargetId()) && (10 == $BlockPosition->getBlockId())) {
+                $showNo++;
+            }
+        }
+        $this->expected = 1;
+        $this->actual = $showNo;
+        $this->verify();
+    }
+
+
     public function testGetPageList()
     {
         $PageLayouts = $this->app['eccube.repository.page_layout']


### PR DESCRIPTION
以下の手順で操作すると、ブロックが複数表示されてしまう。（フロント側でも複数表示される）

1.トップページ以外にブロック（A）を配置
2.トップページにブロック（A）を配置
3.トップページのブロック（A）を全ページ適応とする
4.1のページで同一ブロックが複数配置された状態となる

https://travis-ci.org/hoand-vn/ec-cube
