### PR TITLE
Fix order quantity field

### DIFF
--- a/src/Eccube/Form/Type/Admin/ShipmentItemType.php
+++ b/src/Eccube/Form/Type/Admin/ShipmentItemType.php
@@ -70,7 +70,7 @@ class ShipmentItemType extends AbstractType
                     )),
                 ),
             ))
-            ->add('quantity', 'text', array(
+            ->add('quantity', 'integer', array(
                 'constraints' => array(
                     new Assert\NotBlank(),
                     new Assert\Length(array(

--- a/src/Eccube/Resource/template/admin/Order/edit.twig
+++ b/src/Eccube/Resource/template/admin/Order/edit.twig
@@ -440,9 +440,9 @@ var setModeAndSubmit = function(mode, keyname, keyid) {
                                                     税率：
                                                     <span class="input-group">
                                                     {{ form_widget(orderDetailForm.tax_rate) }}
-                                                    {{ form_errors(orderDetailForm.tax_rate) }}
                                                     <span class="input-group-addon">%</span>
                                                     </span>
+                                                    {{ form_errors(orderDetailForm.tax_rate) }}
                                                 </span>
                                             </div>
                                             <div id="product_info_list__total_price--{{ loop.index }}" class="col-md-12 col-lg-3 item_subtotal text-right">


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ Issues: #2390, #2405
+ This PR to fix validate the order quantity field when multi shipping was enable.

## 方針(Policy)
+ The alphabet can not be entered in the quantity field.
+ When entering zero, the product will be removed.

## 実装に関する補足(Appendix)
+ Fix validate quantity.
+ Fix tax rate error message location.

## テスト（Test)
+ Multi shipping OFF.
+ Multi shipping ON.
+ Add new a product.
+ Delete a product.
+ Input zero.

## 相談（Discussion）