### PR TITLE
税金計算周りの改善

### DIFF
--- a/src/Eccube/Controller/Admin/Shipping/EditController.php
+++ b/src/Eccube/Controller/Admin/Shipping/EditController.php
@@ -135,20 +135,6 @@ class EditController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            // TODO: Should move logic out of controller such as service, modal
-
-            // FIXME 税額計算は CalculateService で処理する. ここはテストを通すための暫定処理
-            // see EditControllerTest::testOrderProcessingWithTax
-            $OrderItems = $TargetShipping->getOrderItems();
-            $taxtotal = 0;
-            foreach ($OrderItems as $OrderItem) {
-                $tax = $this->taxRuleService
-                    ->calcTax($OrderItem->getPrice(), $OrderItem->getTaxRate(), $OrderItem->getTaxRule());
-                $OrderItem->setPriceIncTax($OrderItem->getPrice() + $tax);
-
-                $taxtotal += $tax * $OrderItem->getQuantity();
-            }
-
             log_info('出荷登録開始', [$TargetShipping->getId()]);
             // TODO 在庫の有無や販売制限数のチェックなども行う必要があるため、完了処理もcaluclatorのように抽象化できないか検討する.
             // TODO 後続にある会員情報の更新のように、完了処理もcaluclatorのように抽象化できないか検討する.

--- a/src/Eccube/Doctrine/EventSubscriber/TaxRuleEventSubscriber.php
+++ b/src/Eccube/Doctrine/EventSubscriber/TaxRuleEventSubscriber.php
@@ -71,13 +71,6 @@ class TaxRuleEventSubscriber implements EventSubscriber
             $entity->setPrice02IncTax($this->getTaxRuleService()->getPriceIncTax($entity->getPrice02(),
                 $entity->getProduct(), $entity));
         }
-        if ($entity instanceof OrderItem) {
-            $entity->setPriceIncTax($entity->getPrice());
-            if ($entity->isProduct()) {
-                $entity->setPriceIncTax($this->getTaxRuleService()->getPriceIncTax($entity->getPrice(),
-                    $entity->getProduct(), $entity->getProductClass()));
-            }
-        }
     }
 
     public function postLoad(LifecycleEventArgs $args)
@@ -89,14 +82,6 @@ class TaxRuleEventSubscriber implements EventSubscriber
                 $entity->getProduct(), $entity));
             $entity->setPrice02IncTax($this->getTaxRuleService()->getPriceIncTax($entity->getPrice02(),
                 $entity->getProduct(), $entity));
-        }
-        if ($entity instanceof OrderItem) {
-            $entity->setPriceIncTax($entity->getPrice());
-
-            if ($entity->isProduct()) {
-                $entity->setPriceIncTax($this->getTaxRuleService()->getPriceIncTax($entity->getPrice(),
-                    $entity->getProduct(), $entity->getProductClass()));
-            }
         }
     }
 
@@ -110,13 +95,6 @@ class TaxRuleEventSubscriber implements EventSubscriber
             $entity->setPrice02IncTax($this->getTaxRuleService()->getPriceIncTax($entity->getPrice02(),
                 $entity->getProduct(), $entity));
         }
-        if ($entity instanceof OrderItem) {
-            $entity->setPriceIncTax($entity->getPrice());
-            if ($entity->isProduct()) {
-                $entity->setPriceIncTax($this->getTaxRuleService()->getPriceIncTax($entity->getPrice(),
-                    $entity->getProduct(), $entity->getProductClass()));
-            }
-        }
     }
 
     public function postUpdate(LifecycleEventArgs $args)
@@ -128,13 +106,6 @@ class TaxRuleEventSubscriber implements EventSubscriber
                 $entity->getProduct(), $entity));
             $entity->setPrice02IncTax($this->getTaxRuleService()->getPriceIncTax($entity->getPrice02(),
                 $entity->getProduct(), $entity));
-        }
-        if ($entity instanceof OrderItem) {
-            $entity->setPriceIncTax($entity->getPrice());
-            if ($entity->isProduct()) {
-                $entity->setPriceIncTax($this->getTaxRuleService()->getPriceIncTax($entity->getPrice(),
-                    $entity->getProduct(), $entity->getProductClass()));
-            }
         }
     }
 }

--- a/src/Eccube/Entity/Master/TaxType.php
+++ b/src/Eccube/Entity/Master/TaxType.php
@@ -58,5 +58,5 @@ class TaxType extends \Eccube\Entity\Master\AbstractMasterEntity
      *
      * @var integer
      */
-    const TAX_EXEMPT = 2;
+    const TAX_EXEMPT = 3;
 }

--- a/src/Eccube/Entity/OrderItem.php
+++ b/src/Eccube/Entity/OrderItem.php
@@ -41,22 +41,6 @@ class OrderItem extends \Eccube\Entity\AbstractEntity implements ItemInterface
 {
     use PointRateTrait;
 
-    private $price_inc_tax = null;
-
-    /**
-     * Set price IncTax
-     *
-     * @param  string       $price_inc_tax
-     *
-     * @return OrderItem
-     */
-    public function setPriceIncTax($price_inc_tax)
-    {
-        $this->price_inc_tax = $price_inc_tax;
-
-        return $this;
-    }
-
     /**
      * Get price IncTax
      *
@@ -64,10 +48,11 @@ class OrderItem extends \Eccube\Entity\AbstractEntity implements ItemInterface
      */
     public function getPriceIncTax()
     {
+        $TaxType = $this->getTaxType();
         $TaxDisplayType = $this->getTaxDisplayType();
-        if (is_object($TaxDisplayType)) {
+        if (is_object($TaxType) && is_object($TaxDisplayType)) {
             // 課税かつ外税の場合にのみ商品単価に消費税を足した金額を返す
-            if ($this->getTaxType()->getId() == TaxType::TAXATION && $TaxDisplayType->getId() == TaxDisplayType::EXCLUDED) {
+            if ($TaxType->getId() == TaxType::TAXATION && $TaxDisplayType->getId() == TaxDisplayType::EXCLUDED) {
                 // 課税かつ外税の場合は商品単価に消費税を足して返す。
                 return round($this->getPrice() + $this->getPrice() * $this->getTaxRate() / 100, 0);
             } else {
@@ -76,7 +61,7 @@ class OrderItem extends \Eccube\Entity\AbstractEntity implements ItemInterface
             }
         }
 
-        return 0;
+        return $this->getPrice();
     }
 
     /**

--- a/src/Eccube/Form/Type/Admin/OrderItemType.php
+++ b/src/Eccube/Form/Type/Admin/OrderItemType.php
@@ -192,18 +192,6 @@ class OrderItemType extends AbstractType
             if (!$TaxDisplayType) {
                 return;
             }
-            switch ($TaxDisplayType->getId()) {
-                // 税込価格
-                case TaxDisplayType::INCLUDED:
-                    $OrderItem->setPriceIncTax($OrderItem->getPrice());
-                    break;
-                // 税別価格の場合は税額を加算する
-                case TaxDisplayType::EXCLUDED:
-                    // TODO 課税規則を考慮する
-                    $OrderItem->setPriceIncTax($OrderItem->getPrice() + $OrderItem->getPrice() * $OrderItem->getTaxRate() / 100);
-                    break;
-            }
-
             $event->setData($OrderItem);
         });
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {

--- a/src/Eccube/Resource/template/default/Mail/order.twig
+++ b/src/Eccube/Resource/template/default/Mail/order.twig
@@ -41,9 +41,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 {% for OrderItem in Order.OrderItems %}
 商品コード: {{ OrderItem.product_code }}
 商品名: {{ OrderItem.product_name }}  {{ OrderItem.classcategory_name1 }}  {{ OrderItem.classcategory_name2 }}
-単価： {% if OrderItem.isProduct %}{{ calc_inc_tax(OrderItem.price, OrderItem.tax_rate, OrderItem.tax_rule)|price }}
-{% else %}{{ OrderItem.price|price }}
-{% endif %}
+単価： {{ OrderItem.price_inc_tax|price }}
 数量： {{ OrderItem.quantity|number_format }}
 
 {% endfor %}

--- a/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/DeliveryFeeProcessor.php
@@ -108,7 +108,6 @@ class DeliveryFeeProcessor implements ItemHolderProcessor
             $OrderItem = new OrderItem();
             $OrderItem->setProductName(trans('deliveryfeeprocessor.label.shippint_charge'))
                 ->setPrice($Shipping->getShippingDeliveryFee())
-                ->setPriceIncTax($Shipping->getShippingDeliveryFee())
                 ->setTaxRate(8)
                 ->setQuantity(1)
                 ->setOrderItemType($DeliveryFeeType)

--- a/src/Eccube/Service/PurchaseFlow/Processor/UsePointProcessor.php
+++ b/src/Eccube/Service/PurchaseFlow/Processor/UsePointProcessor.php
@@ -91,7 +91,6 @@ class UsePointProcessor implements ItemHolderProcessor
         $OrderItem = new OrderItem();
         $OrderItem->setProductName('ポイント値引')
             ->setPrice($priceOfUsePoint)
-            ->setPriceIncTax($priceOfUsePoint)
             ->setTaxRate(8)
             ->setQuantity(1)
             ->setOrderItemType($DiscountType)

--- a/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
+++ b/src/Eccube/Service/PurchaseFlow/PurchaseFlow.php
@@ -104,11 +104,7 @@ class PurchaseFlow
     protected function calculateTotal(ItemHolderInterface $itemHolder)
     {
         $total = $itemHolder->getItems()->reduce(function ($sum, ItemInterface $item) {
-            if ($item->isProduct()) {
-                $sum += $item->getPriceIncTax() * $item->getQuantity();
-            } else {
-                $sum += $item->getPrice() * $item->getQuantity();
-            }
+            $sum += $item->getPriceIncTax() * $item->getQuantity();
 
             return $sum;
         }, 0);
@@ -144,7 +140,7 @@ class PurchaseFlow
         $total = $itemHolder->getItems()
             ->getDeliveryFees()
             ->reduce(function ($sum, ItemInterface $item) {
-                $sum += $item->getPrice() * $item->getQuantity();
+                $sum += $item->getPriceIncTax() * $item->getQuantity();
 
                 return $sum;
             }, 0);
@@ -159,7 +155,7 @@ class PurchaseFlow
         $total = $itemHolder->getItems()
             ->getDiscounts()
             ->reduce(function ($sum, ItemInterface $item) {
-                $sum += $item->getPrice() * $item->getQuantity();
+                $sum += $item->getPriceIncTax() * $item->getQuantity();
 
                 return $sum;
             }, 0);
@@ -187,6 +183,7 @@ class PurchaseFlow
      */
     protected function calculateTax(ItemHolderInterface $itemHolder)
     {
+        // FIXME: $item->getPrice()で税抜き価格が得られるとは限らないので以下の計算は必ずしも正確では無い
         $total = $itemHolder->getItems()
             ->reduce(function ($sum, ItemInterface $item) {
                 $sum += ($item->getPriceIncTax() - $item->getPrice()) * $item->getQuantity();

--- a/tests/Eccube/Tests/Web/Admin/Order/AbstractEditControllerTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/AbstractEditControllerTestCase.php
@@ -125,6 +125,7 @@ abstract class AbstractEditControllerTestCase extends AbstractAdminWebTestCase
                 'quantity' => $OrderItem->getQuantity(),
                 'tax_rate' => $OrderItem->getTaxRate(),
                 'tax_rule' => $OrderItem->getTaxRule(),
+                'tax_type' => TaxType::TAXATION,
                 'product_name' => is_object($Product) ? $Product->getName() : '送料', // XXX v3.1 より 送料等, Product の無い明細が追加される
                 'product_code' => is_object($ProductClass) ? $ProductClass->getCode() : null,
                 'order_item_type' => $OrderItem->getOrderItemTypeId(),

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -25,11 +25,10 @@ namespace Eccube\Tests\Web\Admin\Order;
 
 use Eccube\Common\Constant;
 use Eccube\Entity\BaseInfo;
-use Eccube\Entity\Master\OrderItemType;
-use Eccube\Entity\Order;
 use Eccube\Repository\CustomerRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Service\CartService;
+use Eccube\Service\TaxRuleService;
 
 class EditControllerTest extends AbstractEditControllerTestCase
 {
@@ -392,13 +391,11 @@ class EditControllerTest extends AbstractEditControllerTestCase
 
         //税金計算
         $totalTax = 0;
-        foreach ($formDataForEdit['OrderItems'] as $indx => $orderItem) {
-            if ($orderItem['order_item_type'] == OrderItemType::PRODUCT) {
-                // Todo don't use TaxRuleService::calcTax
-//                $tax = $this->container->get(TaxRuleService::class)->calcTax($orderItem['price'], $orderItem['tax_rate'], $orderItem['tax_rule']);
-                $tax = (int) $orderItem['price'] * $orderItem['tax_rate'] / 100;
-                $totalTax += $tax * $formDataForEdit['OrderItems'][$indx]['quantity'];
-            }
+        foreach ($formDataForEdit['OrderItems'] as $index => $orderItem) {
+            //商品数変更3個追加
+            $formDataForEdit['OrderItems'][$index]['quantity'] = $orderItem['quantity'] + 3;
+            $tax = (int) $this->container->get(TaxRuleService::class)->calcTax($orderItem['price'], $orderItem['tax_rate'], $orderItem['tax_rule']);
+            $totalTax += $tax * $formDataForEdit['OrderItems'][$index]['quantity'];
         }
 
         // 管理画面で受注編集する
@@ -410,11 +407,11 @@ class EditControllerTest extends AbstractEditControllerTestCase
         );
 
         $this->assertTrue($this->client->getResponse()->isRedirect($this->generateUrl('admin_order_edit', ['id' => $Order->getId()])));
-        $EditedOrderafterEdit = $this->orderRepository->find($Order->getId());
+        $EditedOrderAfterEdit = $this->orderRepository->find($Order->getId());
 
         //確認する「トータル税金」
-        $this->expected = round($totalTax, 2);
-        $this->actual = $EditedOrderafterEdit->getTax();
+        $this->expected = $totalTax;
+        $this->actual = $EditedOrderAfterEdit->getTax();
         $this->verify();
     }
 

--- a/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
+++ b/tests/Eccube/Tests/Web/Admin/Order/EditControllerTest.php
@@ -25,6 +25,7 @@ namespace Eccube\Tests\Web\Admin\Order;
 
 use Eccube\Common\Constant;
 use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Master\OrderItemType;
 use Eccube\Repository\CustomerRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Service\CartService;
@@ -392,9 +393,12 @@ class EditControllerTest extends AbstractEditControllerTestCase
         //税金計算
         $totalTax = 0;
         foreach ($formDataForEdit['OrderItems'] as $index => $orderItem) {
-            //商品数変更3個追加
-            $formDataForEdit['OrderItems'][$index]['quantity'] = $orderItem['quantity'] + 3;
-            $tax = (int) $this->container->get(TaxRuleService::class)->calcTax($orderItem['price'], $orderItem['tax_rate'], $orderItem['tax_rule']);
+            if ($orderItem['order_item_type'] == OrderItemType::PRODUCT) {
+                //商品数変更3個追加
+                $formDataForEdit['OrderItems'][$index]['quantity'] = $orderItem['quantity'] + 3;
+            }
+            $tax = (int)$this->container->get(TaxRuleService::class)->calcTax($orderItem['price'],
+                $orderItem['tax_rate'], $orderItem['tax_rule']);
             $totalTax += $tax * $formDataForEdit['OrderItems'][$index]['quantity'];
         }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ 消費税の計算が散らばっていたのでOrderItemのEntity内で計算をするように修正。
+ 課税かつ外税の場合にのみ商品単価に消費税を足すように修正。

TODO: 改善できていない課題
- 税金の計算処理がTaxRuleServiceとOrderItemの２箇所に別れている
- dtp_order_itemにrounding_typeのカラムがなく、購入時の税金丸め処理がDBに保存できていないためEntity内で正確に計算ができない。

## 方針(Policy)
+ 散らばっている税金の計算処理をなるべく１箇所にまとめる。
+ Entity/OrderItem.phpの$price_inc_taxのクラス変数は不要なので削除。

## 実装に関する補足(Appendix)
+ 以下の課題が残っている
  - 税金の計算処理がTaxRuleServiceとOrderItemの２箇所に別れている
  - dtp_order_itemにrounding_typeのカラムがなく、購入時の税金丸め処理がDBに保存できていないためEntity内で正確に計算ができない。

## テスト（Test)
+ ローカルでテストが通ることを確認
